### PR TITLE
Update diy-part2.sh

### DIFF
--- a/scripts/diy-part2.sh
+++ b/scripts/diy-part2.sh
@@ -40,7 +40,7 @@ git clone --depth=1 https://github.com/ysc3839/luci-proto-minieap
 git clone --depth=1 https://github.com/tty228/luci-app-serverchan
 
 # Add OpenClash
-git clone --depth=1 -b master https://github.com/vernesong/OpenClash
+git clone --depth 1 -b oaf-3.0.1 https://github.com/destan19/OpenAppFilter.git
 
 # Add luci-app-onliner
 git clone --depth=1 https://github.com/rufengsuixing/luci-app-onliner


### PR DESCRIPTION
日志显示OpenAppFilter导致失败，把版本退回oaf-3.0.1即可，与内核5.10不兼容