### PR TITLE
Rename r3p r3g

### DIFF
--- a/config/MIPS/r3g.config
+++ b/config/MIPS/r3g.config
@@ -1,3 +1,3 @@
 CONFIG_TARGET_ramips=y
 CONFIG_TARGET_ramips_mt7621=y
-CONFIG_TARGET_ramips_mt7621_DEVICE_xiaomi_mir3g=y
+CONFIG_TARGET_ramips_mt7621_DEVICE_xiaomi_mi-router-3g=y

--- a/config/MIPS/r3p.config
+++ b/config/MIPS/r3p.config
@@ -1,3 +1,3 @@
 CONFIG_TARGET_ramips=y
 CONFIG_TARGET_ramips_mt7621=y
-CONFIG_TARGET_ramips_mt7621_DEVICE_xiaomi_mir3p=y
+CONFIG_TARGET_ramips_mt7621_DEVICE_xiaomi_mi-router-3-pro=y


### PR DESCRIPTION
lede 的源码更新了 r3p r3g 这两个路由器的名称，导致github action无法编译出正确的固件

（可能有其他的路由器名称也改变了，因为种类太多无法一一验证）