### PR TITLE
fix #68 fix MIPS build config zsh shell missing

### DIFF
--- a/config/MIPS/MIPS-extra.config
+++ b/config/MIPS/MIPS-extra.config
@@ -35,6 +35,7 @@ CONFIG_PACKAGE_htop=y
 CONFIG_PACKAGE_curl=y
 CONFIG_PACKAGE_wget=y
 CONFIG_PACKAGE_tcpdump=y
+CONFIG_PACKAGE_zsh=y
 
 # add ipv6 support
 CONFIG_PACKAGE_dnsmasq_full_dhcpv6=y


### PR DESCRIPTION
fix MIPS build config zsh shell missing